### PR TITLE
Fix newname => selector pairs

### DIFF
--- a/src/columns.jl
+++ b/src/columns.jl
@@ -246,7 +246,6 @@ column(c, x) = columns(c)[colindex(c, x)]
 end
 
 column(t, a::AbstractArray) = a
-column(t, a::Pair{Symbol, <:AbstractArray}) = column(t, a[2])
 column(t, a::Pair{Symbol, <:Any}) = column(t, a[2]) # :newname => selector
 column(t, a::Pair{<:Any, <:Base.Callable}) = map(a[2], rows(t, a[1]))
 column(t, a::Pair{Symbol, <:Base.Callable}) = map(a[2], rows(t, a[1])) # need a tiebreaker for above two

--- a/src/columns.jl
+++ b/src/columns.jl
@@ -227,10 +227,10 @@ function _colindex(fnames::Union{Tuple, AbstractArray}, col, default=nothing)
         return 0
     elseif isa(col, Tuple)
         return 0
-    elseif isa(col, Pair{Symbol, <:Pair}) # recursive pairs
-        return _colindex(fnames, col[2])
-    elseif isa(col, Pair{<:Any, <:Any})
+    elseif isa(col, Pair{<:Any, <:Base.Callable}) # selector => mapfn
         return _colindex(fnames, col[1])
+    elseif isa(col, Pair{Symbol, <:Any}) # :newname => selector
+        return _colindex(fnames, col[2])
     elseif isa(col, AbstractArray)
         return 0
     end
@@ -247,8 +247,9 @@ end
 
 column(t, a::AbstractArray) = a
 column(t, a::Pair{Symbol, <:AbstractArray}) = column(t, a[2])
-column(t, a::Pair{Symbol, <:Pair}) = rows(t, a[2]) # renaming a selection
-column(t, a::Pair{<:Any, <:Any}) = map(a[2], rows(t, a[1]))
+column(t, a::Pair{Symbol, <:Any}) = column(t, a[2]) # :newname => selector
+column(t, a::Pair{<:Any, <:Base.Callable}) = map(a[2], rows(t, a[1]))
+column(t, a::Pair{Symbol, <:Base.Callable}) = map(a[2], rows(t, a[1])) # need a tiebreaker for above two
 column(t, s::SpecialSelector) = rows(t, lowerselection(t, s))
 
 function columns(c, sel::Union{Tuple, SpecialSelector})

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -784,6 +784,8 @@ end
     @test select(tbl, (:x, :t, :z => [3, 4])) == table([2, 1], [0.01, 0.05], [3, 4], names=Symbol[:x, :t, :z])
     @test select(tbl, (:x, :t, :minust => (:t => (-)))) == table([2, 1], [0.01, 0.05], [-0.01, -0.05], names=Symbol[:x, :t, :minust])
     @test select(tbl, (:x, :t, :vx => ((:x, :t) => (p->p.x / p.t)))) == table([2, 1], [0.01, 0.05], [200.0, 20.0], names=Symbol[:x, :t, :vx])
+    @test select(tbl, (:x, :yy => :y)) == table([2, 1], [3, 4], names=Symbol[:x, :yy])
+    @test select(tbl, (:x, :yy => :y => (p->p.+1))) == table([2, 1], [4, 5], names=Symbol[:x, :yy])
 
     a = ndsparse(([1,1,2,2], [1,2,1,2]), [6,7,8,9])
     @test selectkeys(a, 1, agg=+) == ndsparse([1,2], [13,17])


### PR DESCRIPTION
This should fix #279 , that is, make `select(tbl, (:newname => :existing,))` work.

One note is that it's now not possible to to select `:col => mapfn` when `!(mapFn isa Function)`. I don't think it's possible to resolve this succinctly/with dispatch (see: https://discourse.julialang.org/t/functions-and-callable-methods/2983). A workaround for users using functors like this would be `select(tbl, (mapFn.(tbl.columns.col),))`.

If the above is not acceptable, then alternatively I could special-case the selector `Pair{Symbol, Union{Symbol, Int, String, AbstractArray}}`, but this seems less general that ideal.