### PR TITLE
add join iterator

### DIFF
--- a/src/IndexedTables.jl
+++ b/src/IndexedTables.jl
@@ -6,8 +6,8 @@ using OnlineStatsBase: OnlineStat, fit!
 
 using StructArrays: StructVector, StructArray, fieldarrays,
     refine_perm!, collect_structarray,
-    append!!, replace_storage, GroupPerm, GroupJoinPerm,
-    roweq, rowcmp, index_type
+    append!!, replace_storage, GroupPerm,
+    roweq, index_type
 
 import Tables, TableTraits, IteratorInterfaceExtensions, TableTraitsUtils
 

--- a/src/join.jl
+++ b/src/join.jl
@@ -1,3 +1,69 @@
+# Important, for broadcast joins we cannot assume c and d have same number of columns:
+# c could have more columns than d
+rowcmp(::Tuple, i, ::Tuple{}, j) = 0
+
+function rowcmp(tc::Tuple, i, td::Tuple, j)
+    c, d = tc[1], td[1]
+    let k = rowcmp(c, i, d, j)
+        (k == 0) ? rowcmp(tail(tc), i, tail(td), j) : k
+    end
+end
+
+function rowcmp(c::Columns, i, d::Columns, j)
+    tc = Tuple(fieldarrays(c))
+    td = Tuple(fieldarrays(d))
+    return rowcmp(tc, i, td, j)
+end
+
+@inline function rowcmp(c::AbstractVector, i, d::AbstractVector, j)
+    cmp(c[i], d[j])
+end
+
+struct GroupJoinPerm{LP<:GroupPerm, RP<:GroupPerm}
+    left::LP
+    right::RP
+end
+
+GroupJoinPerm(lkeys::AbstractVector, rkeys::AbstractVector, lperm=sortperm(lkeys), rperm=sortperm(rkeys)) =
+    GroupJoinPerm(GroupPerm(lkeys, lperm), GroupPerm(rkeys, rperm))
+
+function _pick(s, a, b)
+    if a === nothing && b === nothing
+        return nothing
+    elseif a === nothing
+        return (1:0, b[1]), (1, a, b)
+    elseif b === nothing
+        return (a[1], 1:0), (-1, a, b)
+    else
+        lp = sortperm(s.left)
+        rp = sortperm(s.right)
+        cmp = rowcmp(parent(s.left), lp[first(a[1])], parent(s.right), rp[first(b[1])])
+        if cmp < 0
+            return (a[1], 1:0), (-1, a, b)
+        elseif cmp == 0
+            return (a[1], b[1]), (0, a, b)
+        else
+            return (1:0, b[1]), (1, a, b)
+        end
+    end
+end
+
+function Base.iterate(s::GroupJoinPerm)
+    l = iterate(s.left)
+    r = iterate(s.right)
+    _pick(s, l, r)
+end
+
+function Base.iterate(s::GroupJoinPerm, (select, l, r))
+    (select <= 0) && (l = iterate(s.left, l[2]))
+    (select >= 0) && (r = iterate(s.right, r[2]))
+    _pick(s, l, r)
+end
+
+Base.IteratorSize(::Type{<:GroupJoinPerm}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:GroupJoinPerm}) = Base.HasEltype()
+Base.eltype(::Type{<:GroupJoinPerm}) = Tuple{UnitRange{Int}, UnitRange{Int}}
+
 # Missing
 nullrow(t::Type{<:Tuple}, ::Type{Missing}) = Tuple(map(x->missing, fieldtypes(t)))
 nullrow(t::Type{<:NamedTuple}, ::Type{Missing}) = t(Tuple(map(x->missing, fieldtypes(t))))

--- a/test/test_join.jl
+++ b/test/test_join.jl
@@ -59,3 +59,16 @@
         @test isequal(res, table((key = ["a","b","c"], value = [1,2,missing])))
     end
 end
+
+@testset "groupjoin iterator" begin
+    a = [1, 2, 1, 1, 0, 9, -100]
+    b = [-2, 12, 1, 1, 0, 11, 9]
+    itr = IndexedTables.GroupJoinPerm(a, b)
+    @test Base.IteratorSize(itr) == Base.SizeUnknown()
+    @test Base.IteratorEltype(itr) == Base.HasEltype()
+    @test eltype(itr) == Tuple{UnitRange{Int}, UnitRange{Int}}
+    s = collect_columns(itr)
+    as, bs = columns(s)
+    @test as == [1:1, 1:0, 2:2, 3:5, 6:6, 7:7, 1:0, 1:0]
+    @test bs == [1:0, 1:1, 2:2, 3:4, 1:0, 5:5, 6:6, 7:7]
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -74,3 +74,15 @@ end
     @test refa isa WeakRefStrings.StringArray{Union{Missing, WeakRefStrings.WeakRefString{UInt8}}}
     @test all(isequal.(a, refa))
 end
+
+@testset "rowcmp" begin
+    a = ["a", "b", "a", "a"]
+    b = PooledArrays.PooledArray(["x", "y", "z", "x"])
+    s = Columns((a, b))
+    a = ["a", "c", "z", "a"]
+    b = PooledArrays.PooledArray(["p", "y", "a", "x"])
+    t = Columns((a, b))
+    @test IndexedTables.rowcmp(s, 4, t, 4) == 0
+    @test IndexedTables.rowcmp(s, 1, t, 1) == 1
+    @test IndexedTables.rowcmp(s, 2, t, 3) == -1
+end


### PR DESCRIPTION
This moves an iterator that is only needed in IndexedTables from StructArrays. It is essentially a lazy join done via a merge sort between sorted iterators.

I'm planning to remove it from StructArrays in the next breaking release (see https://github.com/JuliaArrays/StructArrays.jl/pull/166), so I'm making this PR to make the update (from StructArrays 0.4 to 0.5) easier for IndexedTables.

On my machine I get some error during testing about WeakRefStrings, but they seem unrelated. (EDIT: never mind, CI passes here, I must have some dependencies devved locally.)